### PR TITLE
feat: Add statusToken endpoint to PurchaseController

### DIFF
--- a/ccemuc-api/src/routes/purchase.routes.ts
+++ b/ccemuc-api/src/routes/purchase.routes.ts
@@ -11,5 +11,6 @@ router.get('/:id', purchaseController.getById);
 router.put('/:id', purchaseController.update);
 router.delete('/:id', authMiddleware, purchaseController.delete);
 router.post('/confirm/:id', purchaseController.confirm);
+router.get('/statusToken/:token', purchaseController.statusToken);
 
 export default router;


### PR DESCRIPTION
The code changes in the `PurchaseController` add a new `statusToken` endpoint. This endpoint handles the status of a transaction token received from Transbank. It checks if the token is present and then confirms the transaction status. If the token is missing, it returns a 400 error. If there is an error during the confirmation process, it returns a 500 error. Otherwise, it returns the transaction status.

This commit adds the `statusToken` endpoint to the `PurchaseController`.